### PR TITLE
route-page-display

### DIFF
--- a/frontend/spot-on/src/App.jsx
+++ b/frontend/spot-on/src/App.jsx
@@ -5,11 +5,13 @@ import {
   Route,
   Navigate,
 } from "react-router-dom";
+import { useState } from "react";
 import Login from "./pages/Login";
 import Home from "./pages/Home";
 import SignUp from "./pages/SignUp";
 import UserProfile from "./pages/UserProfile";
 import Welcome from "./pages/Welcome";
+import RouteDetails from "./component/RouteDetails";
 import { AuthProvider } from "./component/AuthContext";
 import { useAuth } from "./component/AuthContext";
 
@@ -18,6 +20,22 @@ function ProtectedRoute({ children }) {
   return user ? children : <Navigate to="/Welcome" />;
 }
 function AppRoutes() {
+  const [spots, setSpots] = useState([]);
+  const [selectedSpot, setSelectedSpot] = useState([]);
+  const [showModal, setShowModal] = useState(false);
+  const [active, setActive] = useState([]);
+  const [userLocation, setUserLocation] = useState(null);
+  const [locked, setLocked] = useState(false);
+  const [lockedSpotId, setLockedSpotId] = useState(null);
+  const [freeCount, setFreeCount] = useState(0);
+  const [activeFilters, setActiveFilters] = useState({
+    red: true,
+    green: true,
+    white: true,
+    handicap: true,
+    free: true,
+    occupied: true,
+  });
   const { user } = useAuth();
   return (
     <>
@@ -38,7 +56,47 @@ function AppRoutes() {
           path="/"
           element={
             <ProtectedRoute>
-              <Home />
+              <Home
+                spots={spots}
+                setSpots={setSpots}
+                selectedSpot={selectedSpot}
+                setSelectedSpot={setSelectedSpot}
+                showmodal={showModal}
+                setShowModal={setShowModal}
+                active={active}
+                setActive={setActive}
+                userLocation={userLocation}
+                setUserLocation={setUserLocation}
+                locked={locked}
+                setLocked={setLocked}
+                lockedSpotId={lockedSpotId}
+                setLockedSpotId={setLockedSpotId}
+                freeCount={freeCount}
+                setFreeCount={setFreeCount}
+                activeFilters={activeFilters}
+                setActiveFilters={setActiveFilters}
+              />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/Home/RouteDetails"
+          element={
+            <ProtectedRoute>
+              <RouteDetails
+                spots={spots}
+                setSpots={setSpots}
+                setSelectedSpot={setSelectedSpot}
+                setShowModal={setShowModal}
+                setActive={setActive}
+                activeFilters={activeFilters}
+                userLocation={userLocation}
+                locked={locked}
+                setLocked={setLocked}
+                lockedSpotId={lockedSpotId}
+                setLockedSpotId={setLockedSpotId}
+                setFreeCount={setFreeCount}
+              />
             </ProtectedRoute>
           }
         />

--- a/frontend/spot-on/src/component/Fab.jsx
+++ b/frontend/spot-on/src/component/Fab.jsx
@@ -1,0 +1,12 @@
+/** @format */
+import { useNavigate } from "react-router-dom";
+const Fab = ({ onClick }) => {
+  const navigate = useNavigate();
+  return (
+    <button className="fab" onClick={() => navigate("/Home/RouteDetails")}>
+      <i className="fa-solid fa-car"></i>
+    </button>
+  );
+};
+
+export default Fab;

--- a/frontend/spot-on/src/component/LiveStatus.jsx
+++ b/frontend/spot-on/src/component/LiveStatus.jsx
@@ -1,0 +1,25 @@
+/** @format */
+
+const LiveStatus = ({ freeCount }) => {
+  return (
+    <div className="live-stats">
+      <h4>App status</h4>
+      <div className="stat-numbers">
+        <div className="stat-body">
+          <p>{freeCount}</p>
+          <p>Free Lots near u</p>
+        </div>
+        <div className="stat-body">
+          <p>0</p>
+          <p>average week max</p>
+        </div>
+        <div className="stat-body">
+          <p>100%</p>
+          <p>Accuracy</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LiveStatus;

--- a/frontend/spot-on/src/component/QuickActions.jsx
+++ b/frontend/spot-on/src/component/QuickActions.jsx
@@ -1,0 +1,36 @@
+/** @format */
+import { useNavigate } from "react-router-dom";
+const QuickActions = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="quick-actions">
+      <h1>Quick Actions</h1>
+      <div className="actions-body">
+        <div
+          className="actions-div"
+          onClick={() => navigate("/Home/RouteDetails")}
+        >
+          <h3> Smart Routing</h3>
+          <p>Find fastest path </p>
+        </div>
+
+        <div className="actions-div">
+          <h3>Reserve a Spot</h3>
+          <p>Reserve any spot for 10 min</p>
+        </div>
+
+        <div className="actions-div">
+          <h3>Analytics</h3>
+          <p>Your parking pattern</p>
+        </div>
+
+        <div className="actions-div">
+          <h3>Notifications</h3>
+          <p>Personalozed notifications</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuickActions;

--- a/frontend/spot-on/src/component/RouteDetails.jsx
+++ b/frontend/spot-on/src/component/RouteDetails.jsx
@@ -1,0 +1,107 @@
+/** @format */
+import "../styles/Home.css";
+import { useNavigate } from "react-router-dom";
+import Body from "./Body";
+import { use, useState } from "react";
+const RouteDetails = ({
+  spots,
+  setSpots,
+  setSelectedSpot,
+  setShowModal,
+  setActive,
+  activeFilters,
+  userLocation,
+  locked,
+  setLocked,
+  lockedSpotId,
+  setLockedSpotId,
+  setFreeCount,
+}) => {
+  const navigate = useNavigate();
+  const [clicked, setClicked] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
+  return (
+    <>
+      <div className="route-header">
+        <div className="header-icon">
+          <i
+            className="fa fa-arrow-left fa-2x go-back"
+            aria-hidden="true"
+            onClick={() => {
+              navigate("/");
+            }}
+          ></i>
+        </div>
+        <div className="header-text">
+          <p>Find best route to your spot</p>
+          <p>Your spot, yur way</p>
+        </div>
+      </div>
+      <div className="router-toggle">
+        <div
+          className={!clicked ? "active" : "toggle-button"}
+          onClick={() => {
+            setClicked(false);
+            setShowSearch(false);
+          }}
+        >
+          From me to spot
+        </div>
+        <div
+          className={clicked ? "active" : "toggle-button"}
+          onClick={() => {
+            setClicked((f) => !f);
+            setShowSearch(true);
+          }}
+        >
+          From destination to Spot
+        </div>
+      </div>
+      {showSearch && (
+        <div className="search-bar">
+          <input type="text" placeholder="Search for a destination" />
+        </div>
+      )}
+      <div className="site-main">
+        <Body
+          mode="route"
+          name={"Your Smart Router"}
+          spots={spots}
+          setSpots={setSpots}
+          setSelectedSpot={setSelectedSpot}
+          setShowModal={setShowModal}
+          setActive={setActive}
+          activeFilters={activeFilters}
+          userLocation={userLocation}
+          locked={locked}
+          setLocked={setLocked}
+          lockedSpotId={lockedSpotId}
+          setLockedSpotId={setLockedSpotId}
+          setFreeCount={setFreeCount}
+        />
+      </div>
+      <div className="route-summary">
+        <div className="route-summary-header">
+          <h2>Your navigation to </h2>
+        </div>
+        <div className="route-summary-body">
+          <div className="route-summary-item">
+            <p>distance</p>
+            <h2>100 miles</h2>
+          </div>
+
+          <div className="route-summary-item">
+            <p>ETA</p>
+            <h2>12:00</h2>
+          </div>
+
+          <div className="route-summary-item">
+            <p>Accuracy</p>
+            <h2>100%</h2>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+export default RouteDetails;

--- a/frontend/spot-on/src/pages/Home.jsx
+++ b/frontend/spot-on/src/pages/Home.jsx
@@ -6,31 +6,45 @@ import Body from "../component/Body";
 import Footer from "../component/Footer";
 import Report from "../component/Report";
 import { useState, useEffect, useRef } from "react";
+import {
+  BrowserRouter as Router,
+  Routes,
+  Route,
+  Navigate,
+} from "react-router-dom";
 import Message from "../component/Message";
+import QuickActions from "../component/QuickActions";
+import LiveStatus from "../component/LiveStatus";
+import RouteDetails from "../component/RouteDetails";
+import Fab from "../component/Fab";
 import SpotModal from "../component/SpotModal";
 import MapLoading from "../component/MapLoading";
 import "../styles/Home.css";
 import { connectWebSocket, sendWebSocket } from "../utils/websocket";
-const Home = () => {
-  const [spots, setSpots] = useState([]);
-  const [active, setActive] = useState([]);
+const Home = ({
+  spots,
+  setSpots,
+  selectedSpot,
+  setSelectedSpot,
+  showmodal,
+  setShowModal,
+  active,
+  setActive,
+  userLocation,
+  setUserLocation,
+  locked,
+  setLocked,
+  lockedSpotId,
+  setLockedSpotId,
+  freeCount,
+  setFreeCount,
+  activeFilters,
+  setActiveFilters,
+}) => {
   const [message, setMessage] = useState("");
   const [isVisible, setIsVisible] = useState(false);
   const { user } = useAuth();
-  const [selectedSpot, setSelectedSpot] = useState([]);
-  const [showmodal, setShowModal] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
-  const [locked, setLocked] = useState(false);
-  const [lockedSpotId, setLockedSpotId] = useState(null);
-  const [activeFilters, setActiveFilters] = useState({
-    red: true,
-    green: true,
-    white: true,
-    handicap: true,
-    free: true,
-    occupied: true,
-  });
-  const [userLocation, setUserLocation] = useState(null);
   const [userLocationError, setUserLocationError] = useState(null);
   useEffect(() => {
     if (!navigator.geolocation) {
@@ -68,10 +82,12 @@ const Home = () => {
         setSpots([]);
       } else {
         setSpots(data);
+        setFreeCount(data.filter((spot) => spot.isOccupied === false).length);
       }
     };
     // connectWebSocket
     fetchSpots();
+
     connectWebSocket((data) => {
       if (data.type === "SPOT_UPDATED") {
       }
@@ -155,7 +171,10 @@ const Home = () => {
         <MapLoading />
       ) : (
         <main className="site-main">
+          <LiveStatus freeCount={freeCount} />
           <Body
+            mode="Home"
+            name={"Your campus Parking Assistant"}
             spots={spots}
             setSpots={setSpots}
             setSelectedSpot={setSelectedSpot}
@@ -167,6 +186,7 @@ const Home = () => {
             setLocked={setLocked}
             lockedSpotId={lockedSpotId}
             setLockedSpotId={setLockedSpotId}
+            setFreeCount={setFreeCount}
           />
 
           <Report
@@ -176,7 +196,11 @@ const Home = () => {
             setSelectedSpot={setSelectedSpot}
             setIsVisible={setIsVisible}
             setMessage={setMessage}
+            count={freeCount}
           />
+          <QuickActions />
+
+          <Fab />
         </main>
       )}
       {showmodal && (

--- a/frontend/spot-on/src/styles/Home.css
+++ b/frontend/spot-on/src/styles/Home.css
@@ -7,6 +7,7 @@ body {
   --primary-gradient: linear-gradient(135deg, #f5f4f2 0%, #e3e7ef 100%);
   --header-bg: #1c2e46;
   --nav-bg: #dcdee5;
+  --nav-life: #dcdee5;
   --nav-color: #1c2e46;
   --btn-color: #1c2e46;
   --footer-color: #1c2e46;
@@ -26,7 +27,114 @@ body {
   padding-bottom: 1.5rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
+.route-header {
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: var(--header-bg);
+  backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  color: #ccc;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+.header-icon {
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.header-text {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  flex: 1;
+  justify-content: center;
+}
+.route-header p {
+  margin: 0;
+  margin-bottom: 10px;
+}
+.router-toggle {
+  display: flex;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  gap: 1rem;
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
 
+.toggle-button {
+  flex: 1;
+  width: 100%;
+  padding: 10px;
+  border-radius: 5px;
+  border: 2px solid #ccc;
+  font-size: 10px;
+  background: var(--nav-bg);
+  color: #1c2e46;
+  cursor: pointer;
+}
+
+.active {
+  flex: 1;
+  background: #1c2e46;
+  color: #fff;
+  width: 100%;
+  padding: 10px;
+  border-radius: 5px;
+  border: 2px solid #1c2e46;
+  font-size: 10px;
+  cursor: pointer;
+}
+.search-bar {
+  display: flex;
+}
+.search-bar input {
+  flex: 1;
+  padding: 10px;
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+.route-summary {
+  display: flex;
+  flex-direction: column;
+}
+.route-summary-header {
+  background-color: #1c2e46;
+  text-align: center;
+  margin-left: 2rem;
+  margin-right: 2rem;
+}
+.route-summary-header h2 {
+  color: #fff;
+  margin: 0;
+  padding: 0.9rem;
+}
+.route-summary-body {
+  background-color: var(--nav-bg);
+  display: flex;
+  justify-content: space-around;
+  margin-left: 2rem;
+  margin-right: 2rem;
+  margin-bottom: 2rem;
+}
+
+.route-summary-item {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+.route-summary-item h2 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 1rem;
+}
+.route-summary-item p {
+  margin: 0;
+  padding: 0;
+  margin-top: 1rem;
+}
 .site-header img {
   width: 5rem;
   height: 5rem;
@@ -71,11 +179,11 @@ body {
 }
 .site-main {
   display: flex;
-  flex-wrap: wrap;
   gap: var(--spacing);
   padding: var(--spacing) 2rem;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
   min-height: calc(100vh - 200px);
+  flex-direction: column;
 }
 .map-title {
   background-color: #1c2e46;
@@ -83,6 +191,33 @@ body {
   color: #fff;
   text-align: center;
   font-size: 1.4rem;
+}
+.live-stats {
+  display: flex;
+  flex-direction: column;
+  background: var(--nav-life);
+  border-radius: 8px;
+  border: none;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+.stat-numbers {
+  display: flex;
+  justify-content: space-around;
+}
+.stat-body {
+  text-align: center;
+}
+.stat-body p {
+  margin: 0;
+  margin-bottom: 1rem;
+}
+.live-stats h4 {
+  margin: 0;
+  padding: 0;
+  margin-bottom: 1rem;
+  margin-left: 10px;
+  margin-top: 10px;
+  text-align: justify;
 }
 .map-container {
   flex: 1 1 600px;
@@ -98,7 +233,45 @@ body {
   align-items: flex-start;
   justify-content: center;
 }
+.quuick-actions {
+  display: flex;
+  flex-direction: column;
+}
+.actions-body {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+.actions-div {
+  text-align: left;
+  margin: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  background: var(--nav-life);
+  cursor: pointer;
+  box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.3);
+}
+.actions-div h3 {
+  font-weight: 600;
+}
 
+.fab {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: #1c2e46;
+  color: #fff;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  font-size: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
 .report-btn {
   background: var(--nav-color);
   color: #fff;
@@ -114,7 +287,6 @@ body {
 .report-btn:hover {
   transform: translateY(-3px);
 }
-
 .site-footer {
   background: var(--footer-color);
   color: white;


### PR DESCRIPTION
## Description
- Merge route page display and navigation into main
## Implementation
- created a fab icon
- fab icon takes you to route page
- add quick actions div to home page
- display app count above map in home page
- refactor map to display in home and route page based on mode prop passed to map component style route page
- display static map in route navigate back to home page
-toggle between route from user to closest spot and closest spot to destination ## tODO
- Design my own algorithm to calculate best route and define graphs 
## Resources
Current knowledge
## Test plan
- screen recording: [feature display](https://www.loom.com/share/2e57395551f9461daea74a363550705d?sid=e4c01ea3-1892-4f71-a7a4-664cec6056f9)