### PR TITLE
Change in ranked spots display

### DIFF
--- a/frontend/spot-on/src/component/Predictions.jsx
+++ b/frontend/spot-on/src/component/Predictions.jsx
@@ -96,7 +96,6 @@ const Predictions = ({ setIsRoutingToHome, spots }) => {
         <div className="cards-section">
           {otherLots.map((lot) => (
             <div>
-              {console.log(lot.current)}
               <LotPredictionCard
                 key={lot.id}
                 lotName={lot.name}

--- a/frontend/spot-on/src/styles/Home.css
+++ b/frontend/spot-on/src/styles/Home.css
@@ -592,6 +592,44 @@ body {
   width: 100%;
 }
 
+.cluster-group {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  margin: 20px 0;
+  background: #f1f5f9;
+  padding: 10px;
+}
+
+.cluster-header {
+  background: #1c2e46;
+  color: white;
+  padding: 12px 16px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: bold;
+  margin-bottom: 10px;
+  transition: background 0.3s ease;
+}
+
+.cluster-header:hover {
+  background: #365074;
+}
+
+.cluster-spots-dropdown {
+  padding: 10px;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 .error-message {
   color: #ff0000;
   font-size: 0.855rem;

--- a/frontend/spot-on/src/utils/clusterSpots.js
+++ b/frontend/spot-on/src/utils/clusterSpots.js
@@ -16,8 +16,8 @@ const haversine = (lat1, lng1, lat2, lng2) => {
 export const clusterSpots = (spots, clusterRadius = 100) => {
   const clusters = [];
   spots.forEach((spot) => {
-    const lat = Number(spot.coordLat);
-    const lng = Number(spot.coordLng);
+    const lat = Number(spot.coordLat) || Number(spot.lat);
+    const lng = Number(spot.coordLng) || Number(spot.lng);
     let added = false;
     for (const cluster of clusters) {
       const dist = haversine(lat, lng, cluster.centerLat, cluster.centerLng);


### PR DESCRIPTION
## Description: 
- display of free spots in cluster after ranking them
- Merge changes into main
## Milestone
- display ranking in clusters
- when cluster is clicked, a ranking of free spots in cluster drops down
- Styling for dropdown
## Test Plan: 
<img width="1162" height="750" alt="Screenshot 2025-07-22 at 11 47 20 PM" src="https://github.com/user-attachments/assets/8467a2e5-ab06-4dcb-a785-8d930a9356b3" />

<img width="1162" height="750" alt="Screenshot 2025-07-22 at 11 48 05 PM" src="https://github.com/user-attachments/assets/d3656838-32f7-493f-86e3-c2df6e10ad44" />
